### PR TITLE
Removed Facebook Lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,16 +189,6 @@ fullcontact.person.twitter('3rdEden', function (err, data) {
 });
 ```
 
-#### person.facebook(handle, [queue], fn);
-
-Retrieves contact information by Facebook username.
-
-```js
-fullcontact.person.facebook('john.smith', function (err, data) {
-  ..
-});
-```
-
 #### person.phone(handle, [queue], fn);
 
 Retrieves contact information by phone number.

--- a/endpoints/person.js
+++ b/endpoints/person.js
@@ -66,40 +66,6 @@ Person.prototype.twitter = function twitter() {
 };
 
 /**
- * Retrieve contact information by Facebook username.
- *
- * ```js
- * fullcontact.person.facebook('arnout.kazemier', [queue], fn);
- * ```
- *
- * @returns {Person}
- * @api public
- */
-Person.prototype.facebook = function facebook() {
-  var args = this.api.args(arguments, 'queue');
-
-  this.send({ facebookUsername: args.value }, args);
-  return this;
-};
-
-/**
- * Retrieve contact information by Facebook id.
- *
- * ```js
- * fullcontact.person.facebookId('1844599060', [queue], fn);
- * ```
- *
- * @returns {Person}
- * @api public
- */
-Person.prototype.facebookId = function facebook() {
-  var args = this.api.args(arguments, 'queue');
-
-  this.send({ facebookId: args.value }, args);
-  return this;
-};
-
-/**
  * Retrieve contact information by phone number.
  *
  * ```js

--- a/test/person.test.js
+++ b/test/person.test.js
@@ -77,22 +77,6 @@ describe('FullContact.Person', function () {
     it('provides the proper casing');
   });
 
-  describe('#facebook', function () {
-    it('retrieves data by facebook username', function (done) {
-      api.person.facebook('arnout.kazemier', done);
-    });
-
-    it('provides the proper casing');
-  });
-
-  describe('#facebookId', function () {
-    it('retrieves data by facebook id', function (done) {
-      api.person.facebookId('1844599060', done);
-    });
-
-    it('provides the proper casing');
-  });
-
   describe('#phone', function () {
     it('retrieves data by phone number', function (done) {
       api.person.phone('+13037170414', done);


### PR DESCRIPTION
FullContact Person API no longer supports lookups by Facebook Username or ID.