### PR TITLE
Replace email endpoint with latest per-spec methods

### DIFF
--- a/endpoints/email.js
+++ b/endpoints/email.js
@@ -10,27 +10,27 @@
 function Email(api) {
   this.api = api;
 
-  this.endpoint = 'https://api.fullcontact.com/' + api.version + '/email/';
+  this.endpoint = 'https://api.fullcontact.com/' + api.version + '/verification/';
   this.send = api.process.bind(api, this);
 }
 
 /**
- * Check if we we're given a disposable e-mail address.
+ * Verifies the existance of an email address.
  *
  * ```js
- * fullcontact.email.disposable('foo@bar.bar', fn);
+ * fullcontact.email.verify('foo@bar.bar', fn);
  * ```
  *
  * @returns {Email}
  * @api public
  */
-Email.prototype.disposable = function disposable() {
+Email.prototype.verify = function verify() {
   var args = this.api.args(arguments);
 
   //
   // Add a custom endpoint.
   //
-  args.endpoint = this.endpoint + 'disposable.json';
+  args.endpoint = this.endpoint + 'email';
 
   this.send({ email: args.value }, args);
   return this;


### PR DESCRIPTION
The email disposable verification endpoint does not exist per the latest specifications.  In this pull request I have instead made use of the correct email verification endpoint which automatically includes a 'disposable' attribute in the response.